### PR TITLE
feat(analytics): first-party tracker via /_a (ADR-0006 Phase 2c)

### DIFF
--- a/jsdoc.json
+++ b/jsdoc.json
@@ -49,7 +49,7 @@
           "id": "jellyfin-link"
         }
       ],
-      "footer": "<span class=\"jsdoc-message\">Automatically generated using <a href=\"https://github.com/jsdoc/jsdoc\" target=\"_blank\">JSDoc</a> and the <a href=\"https://github.com/ankitskvmdam/clean-jsdoc-theme\" target=\"_blank\">clean-jsdoc-theme</a>.</span><script defer src=\"https://analytics.jellyrock.app/script.js\" data-website-id=\"07139597-641c-42e6-8f5a-cbb0d9182a20\"></script>"
+      "footer": "<span class=\"jsdoc-message\">Automatically generated using <a href=\"https://github.com/jsdoc/jsdoc\" target=\"_blank\">JSDoc</a> and the <a href=\"https://github.com/ankitskvmdam/clean-jsdoc-theme\" target=\"_blank\">clean-jsdoc-theme</a>.</span><script defer src=\"/_a/script.js\" data-website-id=\"07139597-641c-42e6-8f5a-cbb0d9182a20\" data-host-url=\"https://api.jellyrock.app/_a\"></script>"
     }
   },
   "markdown": {


### PR DESCRIPTION
**Phase 2c of ADR-0006.** Switches the api-docs footer Umami embed from cross-origin `analytics.jellyrock.app/script.js` to the same-origin first-party proxy (`/_a/script.js`), live since infra #27.

```
<script defer src="/_a/script.js" data-website-id="…" data-host-url="https://api.jellyrock.app/_a"></script>
```

- Tracker POSTs to `https://api.jellyrock.app/_a/api/send` → Caddy strips `/_a` → umami `/api/send`.
- No CSP risk: `/_a/script.js` is `'self'`. Shared CSP tightens in the final infra phase.
- `analytics.jellyrock.app` stays live as rollback (Bridge).

### Verification
- `jsdoc.json` is valid JSON; footer embeds `/_a/script.js` + `data-host-url`, **0** legacy origin refs.
- The deploy rebuilds the JSDoc site fresh on merge, propagating the footer to every page.
- Post-deploy gate: `analytics-health.sh --only api-docs` → first-party/ok.