### PR TITLE
fix(analytics): point jsdoc footer tracker at first-party /_a

### DIFF
--- a/jsdoc.json
+++ b/jsdoc.json
@@ -49,7 +49,7 @@
           "id": "jellyfin-link"
         }
       ],
-      "footer": "<span class=\"jsdoc-message\">Automatically generated using <a href=\"https://github.com/jsdoc/jsdoc\" target=\"_blank\">JSDoc</a> and the <a href=\"https://github.com/ankitskvmdam/clean-jsdoc-theme\" target=\"_blank\">clean-jsdoc-theme</a>.</span><script defer src=\"https://analytics.jellyrock.app/script.js\" data-website-id=\"07139597-641c-42e6-8f5a-cbb0d9182a20\"></script>"
+      "footer": "<span class=\"jsdoc-message\">Automatically generated using <a href=\"https://github.com/jsdoc/jsdoc\" target=\"_blank\">JSDoc</a> and the <a href=\"https://github.com/ankitskvmdam/clean-jsdoc-theme\" target=\"_blank\">clean-jsdoc-theme</a>.</span><script defer src=\"/_a/script.js\" data-website-id=\"07139597-641c-42e6-8f5a-cbb0d9182a20\" data-host-url=\"https://api.jellyrock.app/_a\"></script>"
     }
   },
   "markdown": {


### PR DESCRIPTION
## What

The jsdoc footer in `jsdoc.json` still embedded the Umami tracker **cross-origin** (`analytics.jellyrock.app/script.js`), even though the live api site already serves it first-party.

## Why it matters

Under the static-site CSP (`script-src 'self'` — plus `'unsafe-inline'` on the doc-site carve-out, ADR-0006) a cross-origin script source is blocked. Nothing is broken right now (live + deployed output are already first-party), but a future docs regeneration from this `jsdoc.json` (the `repository_dispatch` `update.yml` path) would reintroduce the cross-origin embed and re-create the May-2026 analytics-blackout footgun — on api only.

## Fix

Sync the source to the first-party path used everywhere else: `/_a/script.js` + `data-host-url="https://api.jellyrock.app/_a"` so events post to the same-origin `/_a/api/send` proxy.

Source-only change — `deploy.yml` ignores `jsdoc.json`, so this doesn't deploy; it takes effect on the next docs regeneration. JSON validated.

## Note (out of scope)

The committed `docs/` output is independently stale vs. live (no analytics footer at all in the committed HTML), and the live page also loads a cross-origin `html5shiv` from googlecode that the CSP blocks (harmless legacy IE shim). Flagging, not fixing here.